### PR TITLE
Ensure ID within valid range

### DIFF
--- a/src/Codesleeve/Fixture/Drivers/BaseDriver.php
+++ b/src/Codesleeve/Fixture/Drivers/BaseDriver.php
@@ -29,6 +29,6 @@ abstract class BaseDriver
 		$hash = sha1($value);
 		$integerHash = base_convert($hash, 16, 10);
 
-		return (int)substr($integerHash, 0, 10);
+		return (int)substr($integerHash, 0, 8);
 	}
 }


### PR DESCRIPTION
Fixes #3 

99,999,999 possible ID values is sufficient, given that we only need to prevent collisions within a table.